### PR TITLE
fix: check if a user exists in blueprint page

### DIFF
--- a/src/components/SingleBlueprint.js
+++ b/src/components/SingleBlueprint.js
@@ -26,7 +26,7 @@ class SingleBlueprint extends PureComponent
 		return (
 			<EfficientSingleBlueprint
 				blueprintKey={this.props.id}
-				userId={this.props.user.uid}
+				userId={this.props.user?.uid}
 			/>
 		);
 	}


### PR DESCRIPTION
The blueprints page crashes if the user is not logged in.  This change adds a null check before accessing the `uid` property on `user`.

Fixes #306