### PR TITLE
fix: use conditional chaining to fix voteSummary of null

### DIFF
--- a/src/components/BlueprintThumbnail.js
+++ b/src/components/BlueprintThumbnail.js
@@ -19,9 +19,10 @@ BlueprintThumbnail.propTypes = forbidExtraProps({
 	blueprintSummary: BlueprintSummaryProjection,
 });
 
-function BlueprintThumbnail({blueprintSummary})
-{
-	const {key, title, imgurImage, voteSummary: {numberOfUpvotes}} = blueprintSummary;
+function BlueprintThumbnail({
+  blueprintSummary: { key, title, imgurImage, voteSummary },
+}) {
+  const numberOfUpvotes = voteSummary?.numberOfUpvotes;
 
 	const {isSuccess, data} = useFavorites();
 	const authoredResult    = useAuthored();


### PR DESCRIPTION
The site is currently crashing with the error `Uncaught TypeError: can't access property "numberOfUpvotes", t.voteSummary is null`. This change fixes that error by using destructuring to set the initial constants, then using conditional chaining to only dive into `voteSummary` if it is falsey. Unfortunately, default values only work if the value you are replacing is `undefined`, but in our case the value is `null` so the original value will not be replaced.