### PR TITLE
Point the blueprint editor button at the maintained fbe.factorygamefan.com fork

### DIFF
--- a/src/components/single/BlueprintContentHeader.test.tsx
+++ b/src/components/single/BlueprintContentHeader.test.tsx
@@ -1,0 +1,47 @@
+import {render, screen} from '@testing-library/react';
+import BlueprintContentHeader from './BlueprintContentHeader';
+
+const sha = '1b472ffa07106d9380321fb46b1dbd5b465d483b';
+
+describe('BlueprintContentHeader', () => {
+	it('links a single blueprint to the editor at the blueprint root', () => {
+		render(
+			<BlueprintContentHeader
+				data={{blueprint: {item: 'blueprint', labelHtml: 'Solar array'}}}
+				blueprintKey="-KYeNAYQVgk2DcbuORde"
+				blueprintStringSha={sha}
+			/>,
+		);
+
+		const link = screen.getByRole('button');
+		expect(link).toHaveAttribute(
+			'href',
+			`https://fbe.factorygamefan.com/?source=https://www.factorio.school/api/blueprintData/${sha}/`,
+		);
+	});
+
+	it('links each blueprint in a book to its position in the book', () => {
+		render(
+			<BlueprintContentHeader
+				data={{
+					blueprint_book: {
+						item: 'blueprint-book',
+						labelHtml: 'Gleba book',
+						blueprints: [
+							{blueprint: {item: 'blueprint', labelHtml: 'First'}},
+							{blueprint: {item: 'blueprint', labelHtml: 'Second'}},
+						],
+					},
+				}}
+				blueprintKey="-OJczvHV56up6wV6mI3k"
+				blueprintStringSha={sha}
+			/>,
+		);
+
+		const links = screen.getAllByRole('button');
+		expect(links.map((link) => link.getAttribute('href'))).toEqual([
+			`https://fbe.factorygamefan.com/?source=https://www.factorio.school/api/blueprintData/${sha}/position/0`,
+			`https://fbe.factorygamefan.com/?source=https://www.factorio.school/api/blueprintData/${sha}/position/1`,
+		]);
+	});
+});

--- a/src/components/single/BlueprintContentHeader.tsx
+++ b/src/components/single/BlueprintContentHeader.tsx
@@ -72,6 +72,9 @@ function getBlueprintBook(
 	);
 }
 
+// The maintained fork of the blueprint editor; teoxoy's original is unmaintained.
+const FBE_BASE_URL = 'https://fbe.factorygamefan.com/';
+
 function getFbeButton(positionArray: number[], blueprintStringSha: string) {
 	const href = positionArray.length === 0 ? '/' : `/position/${positionArray.join('.')}`;
 
@@ -80,7 +83,7 @@ function getFbeButton(positionArray: number[], blueprintStringSha: string) {
 	return (
 		<Button
 			type="button"
-			href={`https://fbe.teoxoy.com/?source=https://www.factorio.school/api/blueprintData/${blueprintStringSha}${href}`}
+			href={`${FBE_BASE_URL}?source=https://www.factorio.school/api/blueprintData/${blueprintStringSha}${href}`}
 			target="_blank"
 			className="float-end"
 			size="sm"


### PR DESCRIPTION
Points the "Render image" button at [fbe.factorygamefan.com](https://fbe.factorygamefan.com), the maintained fork of the blueprint editor. teoxoy [stopped maintaining](https://github.com/teoxoy/factorio-blueprint-editor/issues/276) the original in August 2026; the fork adds Factorio 2.0 and Space Age support and is actively developed. wormeyman asked for the switch on Discord and is on a Workers paid plan, so the traffic is expected.

Only the host changes. The `?source=` URL is the same `/api/blueprintData/<sha>/position/<i>` shape as before, which the fork passes through to its cors proxy exactly as the old one did.

Verified against the deployed editor, not just in tests — a position link loads the specific sub-blueprint it names:

```
?source=https://www.factorio.school/api/blueprintData/9030bab…/position/0     40 entities, "Early Game - Steam"
?source=https://www.factorio.school/api/blueprintData/9030bab…/position/1.0   197 entities, the nested solar farm
```

The URL is a named constant now, and a new test pins both shapes it builds: the root link for a lone blueprint, and one position link per blueprint in a book.
